### PR TITLE
Fixed error in Mbps query

### DIFF
--- a/top-network-fastnetmon-community.json
+++ b/top-network-fastnetmon-community.json
@@ -98,7 +98,7 @@
               ],
               "intervalFactor": 1,
               "policy": "default",
-              "query": "SELECT mean(\"value\") FROM \"networks\" WHERE \"direction\" = 'incoming' AND \"resource\" = 'bps' AND value > 550000000AND $timeFilter GROUP BY time($__interval), cidr fill(previous)",
+              "query": "SELECT mean(\"value\") FROM \"networks\" WHERE \"direction\" = 'incoming' AND \"resource\" = 'bps' AND value > 550000000 AND $timeFilter GROUP BY time($__interval), cidr fill(previous)",
               "rawQuery": true,
               "refId": "A",
               "resultFormat": "time_series",


### PR DESCRIPTION
The missing space in the incoming Mbps query causes Grafana to show the following error message from InfluxDB:
> error parsing query: invalid duration
